### PR TITLE
Improve installation/deinstallation and add flag to disable scanning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changelog
 3.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix querying the registry for the case when collective.clamav is not installed,
+  properly remove registry settings in uninstall step.
+  [tschorr]
+- Add a flag to enable/disable virus scanning in the configlet.
+  [tschorr]
 
 
 3.0.0 (2021-01-25)

--- a/plone-5.2.x.cfg
+++ b/plone-5.2.x.cfg
@@ -14,5 +14,5 @@ virtualenv = 20.0.35
 # Error: The requirement ('pep517>=0.9') is not allowed by your [versions] constraint (0.8.2)
 pep517 = 0.9.1
 
-# Error: The requirement ('importlib-metadata>=1') is not allowed by your [versions] constraint (0.23)
-importlib-metadata = 2.0.0
+# Error: The requirement ('importlib-metadata>=1') is not allowed by your [versions] constraint (2.0.0)
+importlib-metadata = 3.10.1

--- a/src/collective/clamav/configure.zcml
+++ b/src/collective/clamav/configure.zcml
@@ -6,6 +6,7 @@
 
   <i18n:registerTranslations directory="locales" />
 
+  <include file="upgrades.zcml" />
   <includeDependencies package="." />
 
   <include package=".browser" />

--- a/src/collective/clamav/interfaces.py
+++ b/src/collective/clamav/interfaces.py
@@ -22,6 +22,12 @@ clamdConnectionType = SimpleVocabulary(
 class IAVScannerSettings(Interface):
     """ Schema for the clamav settings
     """
+    clamav_enabled = schema.Bool(
+        title=_(u'Enable Clamav virus scanning'),
+        description=_(u'If set to true virus scanning will be enabled '),
+        default=True,
+        required=True)
+
     clamav_connection = schema.Choice(
         title=_(u'Connection type to clamd'),
         description=_(u'Choose whether clamd is accessible through local '

--- a/src/collective/clamav/profiles/default/metadata.xml
+++ b/src/collective/clamav/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>1000</version>
+  <version>1001</version>
   <dependencies>
   </dependencies>
 </metadata>

--- a/src/collective/clamav/profiles/default/propertiestool.xml
+++ b/src/collective/clamav/profiles/default/propertiestool.xml
@@ -2,6 +2,7 @@
 <object name="portal_properties">
  <object name="clamav_properties" meta_type="Plone Property Sheet" purge="False">
   <property name="title">clamav Properties</property>
+  <property name="clamav_enabled" type="boolean" purge="False">True</property>
   <property name="clamav_connection" type="string" purge="False">net</property>
   <property name="clamav_socket" type="string" purge="False">/var/run/clamd</property>
   <property name="clamav_host" type="string" purge="False">localhost</property>

--- a/src/collective/clamav/profiles/uninstall/registry.xml
+++ b/src/collective/clamav/profiles/uninstall/registry.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<registry>
+    <records interface="collective.clamav.interfaces.IAVScannerSettings" remove="true" />
+</registry>

--- a/src/collective/clamav/upgrades.py
+++ b/src/collective/clamav/upgrades.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+default_profile = 'profile-collective.clamav:default'
+
+
+def upgrade_site(setup):
+    setup.runImportStepFromProfile(default_profile, 'plone.app.registry')

--- a/src/collective/clamav/upgrades.zcml
+++ b/src/collective/clamav/upgrades.zcml
@@ -1,0 +1,17 @@
+<configure
+  xmlns="http://namespaces.zope.org/zope"
+  xmlns:i18n="http://namespaces.zope.org/i18n"
+  xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+  i18n_domain="collective.clamav">
+
+  <genericsetup:upgradeStep
+      title="Add clamav_enabled property"
+      description="Add a boolean property to the configlet that allows to disable virus scanning."
+      source="1000"
+      destination="1001"
+      handler="collective.clamav.upgrades.upgrade_site"
+      sortkey="1"
+      profile="collective.clamav:default"
+      />
+
+</configure>

--- a/src/collective/clamav/validator.py
+++ b/src/collective/clamav/validator.py
@@ -22,8 +22,11 @@ def _scanBuffer(buffer):
         return ''
 
     registry = getUtility(IRegistry)
-    settings = registry.forInterface(IAVScannerSettings)  # noqa: P001
-    if settings is None:
+    try:
+        settings = registry.forInterface(IAVScannerSettings)  # noqa: P001
+    except KeyError:  # Product is not installed
+        return ''
+    if not settings.clamav_enabled:
         return ''
     scanner = getUtility(IAVScanner)
 


### PR DESCRIPTION
This PR

- Fixes querying the registry for scanner settings. Currently `c.clamav` will raise an error when trying to upload a file and the add on is not installed
- Properly removes registry settings in the uninstall profile
- Adds a flag to enable/disable virus scanning in the configlet